### PR TITLE
fix the print bug on loss_recon

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -55,14 +55,14 @@ def eval(config):
             generate_mesh(model, surface_pointcloud.transpose(2,1), config, test_iter)
             test_iter += 1 
 
-        avg_test_loss_recon = avg_test_loss_recon / test_iter
+        avg_test_loss_recon = avg_test_loss_recon/ test_iter
         test_accuracy = avg_test_accuracy / test_iter
         test_recall = avg_test_recall / test_iter
         test_fscore = 2*test_accuracy*test_recall/(test_accuracy + test_recall + 1e-6)
         print("Evaluating: time: %4.4f, loss_total: %.6f, loss_recon: %.6f, loss_primitive: %.6f, acc: %.6f, recall: %.6f, fscore: %.6f" % ( 
                                                                                                     time.time() - start_time, 
                                                                                                     avg_test_loss/test_iter, 
-                                                                                                    avg_test_loss_recon / test_iter, 
+                                                                                                    avg_test_loss_recon , 
                                                                                                     avg_test_loss_primitive/test_iter, 
                                                                                                     test_accuracy, 
                                                                                                     test_recall, 

--- a/train.py
+++ b/train.py
@@ -157,7 +157,7 @@ def train(config):
                                                                                                             config.epoch, 
                                                                                                             time.time() - start_time, 
                                                                                                             avg_test_loss/test_iter_counter, 
-                                                                                                            avg_test_loss_recon / test_iter_counter, 
+                                                                                                            avg_test_loss_recon, 
                                                                                                             avg_test_loss_primitive/test_iter_counter, 
                                                                                                             test_accuracy, 
                                                                                                             test_recall, 


### PR DESCRIPTION
fix the bug that when loss_recon is printed to console the value is divided twice by test_iter which is supposed to be divided once.